### PR TITLE
add database collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Read-only tokens are sufficient.
 | digitalocean_account_floating_ip_limit      | gauge   | 1            | The maximum number of floating ips you can use
 | digitalocean_account_verified               | gauge   | 1            | 1 if your email address was verified
 | digitalocean_build_info                     | gauge   | 1            | A metric with a constant '1' value labeled by version, revision, and branch from which the node_exporter was built.
+| digitalocean_database_status                | gauge   | 9            | The status of the database, 1 if online, 0 otherwise
+| digitalocean_database_nodes                 | gauge   | 9            | The number of nodes in a database cluster
 | digitalocean_domain_record_port             | gauge   | 7            | The port for SRV records
 | digitalocean_domain_record_priority         | gauge   | 7            | The priority for SRV and MX records
 | digitalocean_domain_record_weight           | gauge   | 7            | The weight for SRV records

--- a/collector/database.go
+++ b/collector/database.go
@@ -1,0 +1,139 @@
+package collector
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// DBCollector collects metrics about all databases.
+type DBCollector struct {
+	logger  log.Logger
+	errors  *prometheus.CounterVec
+	client  *godo.Client
+	timeout time.Duration
+
+	DB      *prometheus.Desc
+	DBNodes *prometheus.Desc
+}
+
+// NewDBCollector returns a new DBCollector.
+func NewDBCollector(logger log.Logger, errors *prometheus.CounterVec, client *godo.Client, timeout time.Duration) *DBCollector {
+	errors.WithLabelValues("database").Add(0)
+	labels := []string{
+		"id",
+		"name",
+		"maintenance_window_day",
+		"maintenance_window_hour",
+		"maintenance_window_pending",
+		"region",
+		"size",
+		"engine",
+		"version",
+	}
+	return &DBCollector{
+		logger:  logger,
+		errors:  errors,
+		client:  client,
+		timeout: timeout,
+
+		DB: prometheus.NewDesc(
+			"digitalocean_database_status",
+			"If 1 the database is online, 0 otherwise",
+			labels, nil,
+		),
+		DBNodes: prometheus.NewDesc(
+			"digitalocean_database_nodes",
+			"Number of nodes in a database cluster",
+			labels, nil,
+		),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector.
+func (c *DBCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.DB
+	ch <- c.DBNodes
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *DBCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// create a list to hold our dbs
+	dbs := []godo.Database{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+
+	for {
+		dbPage, resp, err := c.client.Databases.List(ctx, opt)
+		if err != nil {
+			c.errors.WithLabelValues("database").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't list databases",
+				"err", err,
+			)
+		}
+
+		// append the current page's dbs to our list
+		for _, d := range dbPage {
+			dbs = append(dbs, d)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			c.errors.WithLabelValues("database").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current page",
+				"err", err,
+			)
+		}
+
+		opt.Page = page + 1
+	}
+
+	for _, db := range dbs {
+		labels := []string{
+			db.ID,
+			db.Name,
+			db.MaintenanceWindow.Day,
+			db.MaintenanceWindow.Hour,
+			strconv.FormatBool(db.MaintenanceWindow.Pending),
+			db.RegionSlug,
+			db.SizeSlug,
+			db.EngineSlug,
+			db.VersionSlug,
+		}
+		var dbStatus float64
+		// API gives back lowercase string already, this is for assurance
+		if strings.ToLower(db.Status) == "online" {
+			dbStatus = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.DB,
+			prometheus.GaugeValue,
+			dbStatus,
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.DBNodes,
+			prometheus.GaugeValue,
+			float64(db.NumNodes),
+			labels...,
+		)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 	r.MustRegister(collector.NewExporterCollector(logger, Version, Revision, BuildDate, GoVersion, StartTime))
 
 	r.MustRegister(collector.NewAccountCollector(logger, errors, client, timeout))
+	r.MustRegister(collector.NewDBCollector(logger, errors, client, timeout))
 	r.MustRegister(collector.NewDomainCollector(logger, errors, client, timeout))
 	r.MustRegister(collector.NewDropletCollector(logger, errors, client, timeout))
 	r.MustRegister(collector.NewFloatingIPCollector(logger, errors, client, timeout))


### PR DESCRIPTION
Adds support to monitor digitalocean managed databases/caches such as postgres, mysql and redis.