### PR TITLE
Add a monitoring collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Read-only tokens are sufficient.
 | digitalocean_monitoring_memory_cached       | gauge   | 3            | Droplet's cached memory metrics in bytes
 | digitalocean_monitoring_filesystem_free     | gauge   | 5            | Droplet's filesystem free metrics in bytes
 | digitalocean_monitoring_filesystem_size     | gauge   | 5            | Droplet's filesystem size metrics in bytes
-| digitalocean_monitoring_bandwidth           | gauge   | 5            | Droplet's bandwidth metrics in kilobits per second
+| digitalocean_monitoring_bandwidth           | gauge   | 5            | Droplet's bandwidth metrics in megabits per second
 
 ### Alerts & Recording Rules
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Read-only tokens are sufficient.
 | digitalocean_spaces_bucket_created          | gauge   | 2            | Spaces bucket creation timestamp in unix epoch format. Includes name and region labels
 | digitalocean_start_time                     | gauge   | 1            | Unix timestamp of the start time
 | digitalocean_volume_size_bytes              | gauge   | 11           | Volume's size in bytes
+| digitalocean_monitoring_cpu                 | gauge   | 4            | Droplet's CPU metrics in seconds
+| digitalocean_monitoring_memory_total        | gauge   | 3            | Droplet's total memory metrics in bytes
+| digitalocean_monitoring_memory_free         | gauge   | 3            | Droplet's free memory metrics in bytes
+| digitalocean_monitoring_memory_available    | gauge   | 3            | Droplet's available memory metrics in bytes
+| digitalocean_monitoring_memory_cached       | gauge   | 3            | Droplet's cached memory metrics in bytes
+| digitalocean_monitoring_filesystem_free     | gauge   | 5            | Droplet's filesystem free metrics in bytes
+| digitalocean_monitoring_filesystem_size     | gauge   | 5            | Droplet's filesystem size metrics in bytes
+| digitalocean_monitoring_bandwidth           | gauge   | 5            | Droplet's bandwidth metrics in kilobits per second
 
 ### Alerts & Recording Rules
 

--- a/collector/droplet.go
+++ b/collector/droplet.go
@@ -24,7 +24,6 @@ type DropletCollector struct {
 	Disk         *prometheus.Desc
 	PriceHourly  *prometheus.Desc
 	PriceMonthly *prometheus.Desc
-	CPUMetrics   *prometheus.Desc
 }
 
 // NewDropletCollector returns a new DropletCollector.
@@ -67,11 +66,6 @@ func NewDropletCollector(logger log.Logger, errors *prometheus.CounterVec, clien
 			"digitalocean_droplet_price_monthly",
 			"Price of the Droplet billed monthly in dollars",
 			labels, nil,
-		),
-		CPUMetrics: prometheus.NewDesc(
-			"digitalocean_droplet_cpu_metrics",
-			"Droplet's CPU metrics in seconds",
-			append(labels, "mode"), nil,
 		),
 	}
 }
@@ -178,32 +172,5 @@ func (c *DropletCollector) Collect(ch chan<- prometheus.Metric) {
 			float64(droplet.Size.PriceMonthly),
 			labels...,
 		)
-
-		metricsReq := &godo.DropletMetricsRequest{
-			HostID: fmt.Sprintf("%d", droplet.ID),
-			Start:  time.Now().Add(-5 * time.Minute),
-			End:    time.Now(),
-		}
-
-		metricsResp, _, err := c.client.Monitoring.GetDropletCPU(ctx, metricsReq)
-		if err != nil {
-			c.errors.WithLabelValues("droplet").Add(1)
-			level.Warn(c.logger).Log(
-				"msg", "can't read current droplet CPU metrics",
-				"err", err,
-			)
-		}
-
-		for _, metric := range metricsResp.Data.Result {
-			lastValue := metric.Values[len(metric.Values)-1].Value
-			mode := fmt.Sprintf("%s", metric.Metric["mode"])
-			CPULabels := append(labels, mode)
-			ch <- prometheus.MustNewConstMetric(
-				c.CPUMetrics,
-				prometheus.GaugeValue,
-				float64(lastValue),
-				CPULabels...,
-			)
-		}
 	}
 }

--- a/collector/monitoring.go
+++ b/collector/monitoring.go
@@ -319,7 +319,7 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				c.BandwidthMetrics,
 				prometheus.GaugeValue,
-				float64(lastValue*1000),
+				float64(lastValue),
 				bandwidthLabels...,
 			)
 		}
@@ -348,7 +348,7 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				c.BandwidthMetrics,
 				prometheus.GaugeValue,
-				float64(lastValue*1000),
+				float64(lastValue),
 				bandwidthLabels...,
 			)
 		}
@@ -377,7 +377,7 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				c.BandwidthMetrics,
 				prometheus.GaugeValue,
-				float64(lastValue*1000),
+				float64(lastValue),
 				bandwidthLabels...,
 			)
 		}

--- a/collector/monitoring.go
+++ b/collector/monitoring.go
@@ -67,16 +67,16 @@ func NewMonitoringCollector(logger log.Logger, errors *prometheus.CounterVec, cl
 		FileSystemFreeMetrics: prometheus.NewDesc(
 			"digitalocean_monitoring_filesystem_free",
 			"Droplet's filesystem free metrics in bytes",
-			append(labels, "device", "fstype"), nil,
+			append(labels, "device", "fstype", "mountpoint"), nil,
 		),
 		FileSystemSizeMetrics: prometheus.NewDesc(
 			"digitalocean_monitoring_filesystem_size",
 			"Droplet's filesystem size metrics in bytes",
-			append(labels, "device", "fstype"), nil,
+			append(labels, "device", "fstype", "mountpoint"), nil,
 		),
 		BandwidthMetrics: prometheus.NewDesc(
 			"digitalocean_monitoring_bandwidth",
-			"Droplet's bandwidth metrics in kilobits per second",
+			"Droplet's bandwidth metrics in megabits per second",
 			append(labels, "interface", "direction"), nil,
 		),
 	}
@@ -262,7 +262,8 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			lastValue := metric.Values[len(metric.Values)-1].Value
 			device := fmt.Sprintf("%s", metric.Metric["device"])
 			fstype := fmt.Sprintf("%s", metric.Metric["fstype"])
-			fsLabels := append(labels, device, fstype)
+			mountpoint := fmt.Sprintf("%s", metric.Metric["mountpoint"])
+			fsLabels := append(labels, device, fstype, mountpoint)
 			ch <- prometheus.MustNewConstMetric(
 				c.FileSystemFreeMetrics,
 				prometheus.GaugeValue,
@@ -284,7 +285,8 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			lastValue := metric.Values[len(metric.Values)-1].Value
 			device := fmt.Sprintf("%s", metric.Metric["device"])
 			fstype := fmt.Sprintf("%s", metric.Metric["fstype"])
-			fsLabels := append(labels, device, fstype)
+			mountpoint := fmt.Sprintf("%s", metric.Metric["mountpoint"])
+			fsLabels := append(labels, device, fstype, mountpoint)
 			ch <- prometheus.MustNewConstMetric(
 				c.FileSystemSizeMetrics,
 				prometheus.GaugeValue,
@@ -404,7 +406,7 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				c.BandwidthMetrics,
 				prometheus.GaugeValue,
-				float64(lastValue*1000),
+				float64(lastValue),
 				bandwidthLabels...,
 			)
 		}

--- a/collector/monitoring.go
+++ b/collector/monitoring.go
@@ -25,6 +25,7 @@ type MonitoringCollector struct {
 	MemoryCachedMetrics    *prometheus.Desc
 	FileSystemFreeMetrics  *prometheus.Desc
 	FileSystemSizeMetrics  *prometheus.Desc
+	BandwidthMetrics       *prometheus.Desc
 }
 
 // NewMonitoringCollector returns a new DropletCollector.
@@ -73,6 +74,11 @@ func NewMonitoringCollector(logger log.Logger, errors *prometheus.CounterVec, cl
 			"Droplet's filesystem size metrics in bytes",
 			append(labels, "device", "fstype"), nil,
 		),
+		BandwidthMetrics: prometheus.NewDesc(
+			"digitalocean_monitoring_bandwidth",
+			"Droplet's bandwidth metrics in kilobits per second",
+			append(labels, "interface", "direction"), nil,
+		),
 	}
 }
 
@@ -86,6 +92,7 @@ func (c *MonitoringCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.MemoryCachedMetrics
 	ch <- c.FileSystemFreeMetrics
 	ch <- c.FileSystemSizeMetrics
+	ch <- c.BandwidthMetrics
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
@@ -283,6 +290,122 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				float64(lastValue),
 				fsLabels...,
+			)
+		}
+
+		resp, _, err = c.client.Monitoring.GetDropletBandwidth(
+			ctx,
+			&godo.DropletBandwidthMetricsRequest{
+				DropletMetricsRequest: *metricsReq,
+				Interface:             "public",
+				Direction:             "inbound",
+			},
+		)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current droplet bandwidth public inbound metrics",
+				"err", err,
+			)
+		}
+
+		for _, metric := range resp.Data.Result {
+			lastValue := metric.Values[len(metric.Values)-1].Value
+			intrfc := fmt.Sprintf("%s", metric.Metric["interface"])
+			direction := fmt.Sprintf("%s", metric.Metric["direction"])
+			bandwidthLabels := append(labels, intrfc, direction)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthMetrics,
+				prometheus.GaugeValue,
+				float64(lastValue*1000),
+				bandwidthLabels...,
+			)
+		}
+
+		resp, _, err = c.client.Monitoring.GetDropletBandwidth(
+			ctx,
+			&godo.DropletBandwidthMetricsRequest{
+				DropletMetricsRequest: *metricsReq,
+				Interface:             "public",
+				Direction:             "outbound",
+			},
+		)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current droplet bandwidth public outbound metrics",
+				"err", err,
+			)
+		}
+
+		for _, metric := range resp.Data.Result {
+			lastValue := metric.Values[len(metric.Values)-1].Value
+			intrfc := fmt.Sprintf("%s", metric.Metric["interface"])
+			direction := fmt.Sprintf("%s", metric.Metric["direction"])
+			bandwidthLabels := append(labels, intrfc, direction)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthMetrics,
+				prometheus.GaugeValue,
+				float64(lastValue*1000),
+				bandwidthLabels...,
+			)
+		}
+
+		resp, _, err = c.client.Monitoring.GetDropletBandwidth(
+			ctx,
+			&godo.DropletBandwidthMetricsRequest{
+				DropletMetricsRequest: *metricsReq,
+				Interface:             "private",
+				Direction:             "inbound",
+			},
+		)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current droplet bandwidth private inbound metrics",
+				"err", err,
+			)
+		}
+
+		for _, metric := range resp.Data.Result {
+			lastValue := metric.Values[len(metric.Values)-1].Value
+			intrfc := fmt.Sprintf("%s", metric.Metric["interface"])
+			direction := fmt.Sprintf("%s", metric.Metric["direction"])
+			bandwidthLabels := append(labels, intrfc, direction)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthMetrics,
+				prometheus.GaugeValue,
+				float64(lastValue*1000),
+				bandwidthLabels...,
+			)
+		}
+
+		resp, _, err = c.client.Monitoring.GetDropletBandwidth(
+			ctx,
+			&godo.DropletBandwidthMetricsRequest{
+				DropletMetricsRequest: *metricsReq,
+				Interface:             "private",
+				Direction:             "outbound",
+			},
+		)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current droplet bandwidth private outbound metrics",
+				"err", err,
+			)
+		}
+
+		for _, metric := range resp.Data.Result {
+			lastValue := metric.Values[len(metric.Values)-1].Value
+			intrfc := fmt.Sprintf("%s", metric.Metric["interface"])
+			direction := fmt.Sprintf("%s", metric.Metric["direction"])
+			bandwidthLabels := append(labels, intrfc, direction)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthMetrics,
+				prometheus.GaugeValue,
+				float64(lastValue*1000),
+				bandwidthLabels...,
 			)
 		}
 	}

--- a/collector/monitoring.go
+++ b/collector/monitoring.go
@@ -1,0 +1,127 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MonitoringCollector collects metrics about all droplets.
+type MonitoringCollector struct {
+	logger  log.Logger
+	errors  *prometheus.CounterVec
+	client  *godo.Client
+	timeout time.Duration
+
+	CPUMetrics *prometheus.Desc
+}
+
+// NewMonitoringCollector returns a new DropletCollector.
+func NewMonitoringCollector(logger log.Logger, errors *prometheus.CounterVec, client *godo.Client, timeout time.Duration) *MonitoringCollector {
+	errors.WithLabelValues("droplet").Add(0)
+
+	labels := []string{"id", "name", "region"}
+	return &MonitoringCollector{
+		logger:  logger,
+		errors:  errors,
+		client:  client,
+		timeout: timeout,
+
+		CPUMetrics: prometheus.NewDesc(
+			"digitalocean_monitoring_cpu",
+			"Droplet's CPU metrics in seconds",
+			append(labels, "mode"), nil,
+		),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector.
+func (c *MonitoringCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.CPUMetrics
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// create a list to hold our droplets
+	droplets := []godo.Droplet{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+
+	for {
+		dropletsPage, resp, err := c.client.Droplets.List(ctx, opt)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't list droplets",
+				"err", err,
+			)
+			return
+		}
+
+		// append the current page's droplets to our list
+		for _, d := range dropletsPage {
+			droplets = append(droplets, d)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current page",
+				"err", err,
+			)
+		}
+
+		opt.Page = page + 1
+	}
+
+	for _, droplet := range droplets {
+		labels := []string{
+			fmt.Sprintf("%d", droplet.ID),
+			droplet.Name,
+			droplet.Region.Slug,
+		}
+
+		metricsReq := &godo.DropletMetricsRequest{
+			HostID: fmt.Sprintf("%d", droplet.ID),
+			Start:  time.Now().Add(-5 * time.Minute),
+			End:    time.Now(),
+		}
+
+		resp, _, err := c.client.Monitoring.GetDropletCPU(ctx, metricsReq)
+		if err != nil {
+			c.errors.WithLabelValues("droplet").Add(1)
+			level.Warn(c.logger).Log(
+				"msg", "can't read current droplet CPU metrics",
+				"err", err,
+			)
+		}
+
+		for _, metric := range resp.Data.Result {
+			lastValue := metric.Values[len(metric.Values)-1].Value
+			mode := fmt.Sprintf("%s", metric.Metric["mode"])
+			CPULabels := append(labels, mode)
+			ch <- prometheus.MustNewConstMetric(
+				c.CPUMetrics,
+				prometheus.GaugeValue,
+				float64(lastValue),
+				CPULabels...,
+			)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 	r.MustRegister(collector.NewVolumeCollector(logger, errors, client, timeout))
 	r.MustRegister(collector.NewKubernetesCollector(logger, errors, client, timeout))
 	r.MustRegister(collector.NewIncidentCollector(logger, errors, timeout))
+	r.MustRegister(collector.NewMonitoringCollector(logger, errors, client, timeout))
 
 	// Only run spaces bucket collector if access key id and secret are set
 	if c.SpacesAccessKeyID != "" && c.SpacesAccessKeySecret != "" {


### PR DESCRIPTION
Add support to retrieve metrics from DigitalOcean monitoring agent.
```
# HELP digitalocean_monitoring_bandwidth Droplet's bandwidth metrics in megabits per second
# TYPE digitalocean_monitoring_bandwidth gauge
digitalocean_monitoring_bandwidth{direction="inbound",id="331890131",interface="private",name="monitoring",region="sgp1"} 3.5e-06
digitalocean_monitoring_bandwidth{direction="inbound",id="331890131",interface="public",name="monitoring",region="sgp1"} 0.08891845
digitalocean_monitoring_bandwidth{direction="inbound",id="335103642",interface="private",name="relayer",region="sgp1"} 4.028776978417266e-06
digitalocean_monitoring_bandwidth{direction="inbound",id="335103642",interface="public",name="relayer",region="sgp1"} 0.48691528057553957
digitalocean_monitoring_bandwidth{direction="outbound",id="331890131",interface="private",name="monitoring",region="sgp1"} 0
digitalocean_monitoring_bandwidth{direction="outbound",id="331890131",interface="public",name="monitoring",region="sgp1"} 0.0102715
digitalocean_monitoring_bandwidth{direction="outbound",id="335103642",interface="private",name="relayer",region="sgp1"} 0
digitalocean_monitoring_bandwidth{direction="outbound",id="335103642",interface="public",name="relayer",region="sgp1"} 0.006332489208633094
# HELP digitalocean_monitoring_cpu Droplet's CPU metrics in seconds
# TYPE digitalocean_monitoring_cpu gauge
digitalocean_monitoring_cpu{id="331890131",mode="idle",name="monitoring",region="sgp1"} 5.13550726e+06
digitalocean_monitoring_cpu{id="331890131",mode="iowait",name="monitoring",region="sgp1"} 2804.8
digitalocean_monitoring_cpu{id="331890131",mode="irq",name="monitoring",region="sgp1"} 0
digitalocean_monitoring_cpu{id="331890131",mode="nice",name="monitoring",region="sgp1"} 576.9
digitalocean_monitoring_cpu{id="331890131",mode="softirq",name="monitoring",region="sgp1"} 362.29999999999995
digitalocean_monitoring_cpu{id="331890131",mode="steal",name="monitoring",region="sgp1"} 3786.93
digitalocean_monitoring_cpu{id="331890131",mode="system",name="monitoring",region="sgp1"} 7947.02
digitalocean_monitoring_cpu{id="331890131",mode="user",name="monitoring",region="sgp1"} 27535.48
digitalocean_monitoring_cpu{id="335103642",mode="idle",name="relayer",region="sgp1"} 1.3431176400000001e+06
digitalocean_monitoring_cpu{id="335103642",mode="iowait",name="relayer",region="sgp1"} 311.35
digitalocean_monitoring_cpu{id="335103642",mode="irq",name="relayer",region="sgp1"} 0
digitalocean_monitoring_cpu{id="335103642",mode="nice",name="relayer",region="sgp1"} 279.19
digitalocean_monitoring_cpu{id="335103642",mode="softirq",name="relayer",region="sgp1"} 280.32
digitalocean_monitoring_cpu{id="335103642",mode="steal",name="relayer",region="sgp1"} 3024.91
digitalocean_monitoring_cpu{id="335103642",mode="system",name="relayer",region="sgp1"} 3412.04
digitalocean_monitoring_cpu{id="335103642",mode="user",name="relayer",region="sgp1"} 15711.099999999999
# HELP digitalocean_monitoring_filesystem_free Droplet's filesystem free metrics in bytes
# TYPE digitalocean_monitoring_filesystem_free gauge
digitalocean_monitoring_filesystem_free{device="/dev/vda1",fstype="ext4",id="331890131",mountpoint="/",name="monitoring",region="sgp1"} 4.8162512896e+10
digitalocean_monitoring_filesystem_free{device="/dev/vda1",fstype="ext4",id="335103642",mountpoint="/",name="relayer",region="sgp1"} 4.7189798912e+10
# HELP digitalocean_monitoring_filesystem_size Droplet's filesystem size metrics in bytes
# TYPE digitalocean_monitoring_filesystem_size gauge
digitalocean_monitoring_filesystem_size{device="/dev/vda1",fstype="ext4",id="331890131",mountpoint="/",name="monitoring",region="sgp1"} 6.2254768128e+10
digitalocean_monitoring_filesystem_size{device="/dev/vda1",fstype="ext4",id="335103642",mountpoint="/",name="relayer",region="sgp1"} 6.2254768128e+10
# HELP digitalocean_monitoring_memory_available Droplet's available memory metrics in bytes
# TYPE digitalocean_monitoring_memory_available gauge
digitalocean_monitoring_memory_available{id="331890131",name="monitoring",region="sgp1"} 1.401225216e+09
digitalocean_monitoring_memory_available{id="335103642",name="relayer",region="sgp1"} 1.463861248e+09
# HELP digitalocean_monitoring_memory_cached Droplet's cached memory metrics in bytes
# TYPE digitalocean_monitoring_memory_cached gauge
digitalocean_monitoring_memory_cached{id="331890131",name="monitoring",region="sgp1"} 1.342271488e+09
digitalocean_monitoring_memory_cached{id="335103642",name="relayer",region="sgp1"} 1.065623552e+09
# HELP digitalocean_monitoring_memory_free Droplet's free memory metrics in bytes
# TYPE digitalocean_monitoring_memory_free gauge
digitalocean_monitoring_memory_free{id="331890131",name="monitoring",region="sgp1"} 1.37990144e+08
digitalocean_monitoring_memory_free{id="335103642",name="relayer",region="sgp1"} 3.16162048e+08
# HELP digitalocean_monitoring_memory_total Droplet's total memory metrics in bytes
# TYPE digitalocean_monitoring_memory_total gauge
digitalocean_monitoring_memory_total{id="331890131",name="monitoring",region="sgp1"} 2.079367168e+09
digitalocean_monitoring_memory_total{id="335103642",name="relayer",region="sgp1"} 2.079367168e+09
```